### PR TITLE
Inference/Enemble: make it possible to use arbitrary amount of models

### DIFF
--- a/darts-postprocessing/src/darts_postprocessing/prepare_export.py
+++ b/darts-postprocessing/src/darts_postprocessing/prepare_export.py
@@ -197,9 +197,13 @@ def prepare_export(
         return tile
 
     tile = _prep_layer(tile, "probabilities", "binarized_segmentation")
-    if "probabilities-tcvis" in tile:
-        tile = _prep_layer(tile, "probabilities-tcvis", "binarized_segmentation-tcvis")
-    if "probabilities-notcvis" in tile:
-        tile = _prep_layer(tile, "probabilities-notcvis", "binarized_segmentation-notcvis")
+
+    # get the names of the model probabilities if available
+    # for example 'tcvis' from 'probabilities-tcvis'
+    aux_probabilities = [
+        name.removeprefix("probabilities-") for name in tile.keys() if name.startswith("probabilities-")
+    ]
+    for aux_prob in aux_probabilities:
+        tile = _prep_layer(tile, f"probabilities-{aux_prob}", f"binarized_segmentation-{aux_prob}")
 
     return tile


### PR DESCRIPTION
Change the API of EnsembleV1 to get a named list of models instead of hardcoded TCVIS and NOTCVIS. During ensembling, a mean of all models is calculated for each pixel.

The CLI tools parameters still keep the TCVIS/NOTCVIS model arguments, but its now possible to leave one empty. In that case, there is essentially no ensembling and the output is just the result of one model.

fixes #90