### PR TITLE
add the option to use a basic stdout logging handler

### DIFF
--- a/darts/src/darts/cli.py
+++ b/darts/src/darts/cli.py
@@ -105,12 +105,13 @@ def launcher(  # noqa: D103
     config_file: Path = Path("config.toml"),
     verbose: bool = False,
     tracebacks_show_locals: bool = False,
+    log_plain: bool = False,
 ):
     command, bound, ignored = app.parse_args(tokens, verbose=verbose)
     # Set verbose to true for debug stuff like env_info
     if command.__name__ == "env_info":
         verbose = True
-    LoggingManager.add_logging_handlers(command.__name__, log_dir, verbose, tracebacks_show_locals)
+    LoggingManager.add_logging_handlers(command.__name__, log_dir, verbose, tracebacks_show_locals, log_plain=log_plain)
     logger.debug(f"Running on Python version {sys.version} from {__name__} ({root_file})")
     additional_args = {}
     if "config_file" in ignored:

--- a/darts/src/darts/pipelines/sequential_v2.py
+++ b/darts/src/darts/pipelines/sequential_v2.py
@@ -53,6 +53,7 @@ class _BasePipeline(ABC):
     )
     write_model_outputs: bool = False
     overwrite: bool = False
+    log_plain: bool = False
 
     @abstractmethod
     def _arcticdem_resolution(self) -> Literal[2, 10, 32]:


### PR DESCRIPTION
On albedo/Slurm the output is piped to a file, and the log width is basically shrunk to about 80 chars which makes the Rich output somewhat unreadable because the actual message has even less space due to the column format of the rich ouput.

add --log-plain to the CLI inference tools, which will use a boring stream handler for the output.

The basic change `LoggingManager.add_logging_handler()` to have the parameter `log_plain`. 

In the `log_plain` case we just use a StreamHandler for logging, otherwise the RichHandler. In both cases the format string will be set differently.

To prevent insconsistent naming, the internal 'rich*' variables are renamed to 'console*'. All other changes expose that setting to the CLI.