### PR TITLE
Modify Ray Pipelines to also work at NCSA

### DIFF
--- a/darts/src/darts/pipelines/ray_v2.py
+++ b/darts/src/darts/pipelines/ray_v2.py
@@ -198,6 +198,7 @@ class _BaseRayPipeline(ABC):
             os.environ["CUDA_VISIBLE_DEVICES"] = "0"  # Or your device index
             os.environ["NVIDIA_VISIBLE_DEVICES"] = "all"
             os.environ["NCCL_DEBUG"] = "INFO"
+            # TODO this needs to be a dynamic check!!!
             os.environ["NCCL_SOCKET_IFNAME"] = "ens3"  # Or your network interface
             os.environ["GLOO_SOCKET_IFNAME"] = "ens3"
             import torch


### PR DESCRIPTION
In attempting to run the new ray pipelines I found that resources were not being allocated properly (CPU, GPU) so we weren't getting any results. 

I have made some changes (small ones) that should not negatively impact running of the pipeline for anyone else, but which will enable us to run on our resources here.

I ran all of these after creating an environment cuda128 using the pixi.toml file. 